### PR TITLE
Bugfix: Fix problem with disappearing hotspot

### DIFF
--- a/src/package.ent
+++ b/src/package.ent
@@ -1,6 +1,6 @@
 <!ENTITY packageVersion "1.1.9">
 <!ENTITY packageVersionV9 "2.0.0">
-<!ENTITY packageVersionV10 "3.0.4">
+<!ENTITY packageVersionV10 "3.0.5">
 <!ENTITY packageVersionV11 "4.0.0">
 
 <!ENTITY packageNamespace "Vokseverk">

--- a/src/propeditor.controller.js
+++ b/src/propeditor.controller.js
@@ -181,13 +181,16 @@ angular.module("umbraco").controller("ImageHotspotController", function($scope, 
 	$scope.storePosition = function (x, y) {
 		$scope.assertImageDimensions()
 
-		var percentX = 100 * x / $scope.image.width
-		var percentY = 100 * y / $scope.image.height
+		var xInt = Math.round(x)
+		var yInt = Math.round(y)
+
+		var percentX = 100 * xInt / $scope.image.width
+		var percentY = 100 * yInt / $scope.image.height
 
 		$scope.model.value = {
 			image: $scope.image.src,
-			left: x,
-			top: y,
+			left: xInt,
+			top: yInt,
 			percentX: percentX,
 			percentY: percentY,
 			width: $scope.image.width,

--- a/umbraco-marketplace.json
+++ b/umbraco-marketplace.json
@@ -6,6 +6,8 @@
 		"Url": "https://greystate.dk/who/"
 	},
 	"Category": "Editor Tools",
+	"LicenseTypes": [ "Free" ],
+	"PackageType": "Package",
 	"Screenshots": [
 		{
 			"ImageUrl": "https://raw.githubusercontent.com/vokseverk/Vokseverk.ImageHotspot/master/images/imagehotspot-editor.jpg",


### PR DESCRIPTION
This adds a fix for #18 by making sure to round the stored values.

This shouldn't be necessary (the `left` and `top` values are pixel positions on the image) but in situations were the displayed image is zoomed or scaled in any way (e.g. if the screen has a 2x resolution but is set to a scaled value) the values returned are floats, which made the `PropertyEditorValueConverter` bail.